### PR TITLE
Checkout PR ref.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,8 +32,10 @@ jobs:
 
     steps:
       - name: Debug Ref Info
+        env:
+          REF: ${{ inputs.REF_TO_CHECKOUT }}
         run: |
-          echo "Checking out ref: ${{ inputs.REF_TO_CHECKOUT }}"
+          echo "Checking out ref: $REF"
 
       - name: Set Default Branch
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,7 +42,7 @@ jobs:
           fi
 
           echo "Checking out ref: $REF_TO_CHECKOUT"
-          echo "$REF_TO_CHECKOUT=$REF_TO_CHECKOUT" >> $GITHUB_OUTPUT
+          echo "REF_TO_CHECKOUT=$REF_TO_CHECKOUT" >> $GITHUB_OUTPUT
 
       - name: Set Default Branch
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,6 +2,12 @@ name: Makefile CI
 
 on:
   workflow_call:
+    inputs:
+      REF_TO_CHECKOUT:
+        description: "The git ref to checkout."
+        required: false
+        default: "refs/heads/main"
+        type: string
     secrets:
       CHECKOUT_SHARED:
         required: true
@@ -25,6 +31,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Debug Ref Info
+        run: |
+          echo "Checking out ref: ${{ inputs.REF_TO_CHECKOUT }}"
+
       - name: Set Default Branch
         run: |
           git config --global init.defaultBranch main
@@ -32,8 +42,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ inputs.REF_TO_CHECKOUT }}
           submodules: recursive
           token: ${{ secrets.CHECKOUT_SHARED }} # Token with full repo scope.
         

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,11 +31,18 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Debug Ref Info
+      - name: Validate and set REF_TO_CHECKOUT
+        id: validate-ref
         env:
-          REF: ${{ inputs.REF_TO_CHECKOUT }}
+          REF_TO_CHECKOUT: ${{ inputs.REF_TO_CHECKOUT }}
         run: |
-          echo "Checking out ref: $REF"
+          if [[ ! "$REF_TO_CHECKOUT" =~ ^refs/(heads|pull|tags)/[A-Za-z0-9._/-]+$ ]]; then
+            echo "Invalid ref: $REF_TO_CHECKOUT"
+            exit 1
+          fi
+
+          echo "Checking out ref: $REF_TO_CHECKOUT"
+          echo "$REF_TO_CHECKOUT=$REF_TO_CHECKOUT" >> $GITHUB_OUTPUT
 
       - name: Set Default Branch
         run: |
@@ -44,7 +51,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.REF_TO_CHECKOUT }}
+          ref: ${{ steps.validate-ref.outputs.REF_TO_CHECKOUT }}
           submodules: recursive
           token: ${{ secrets.CHECKOUT_SHARED }} # Token with full repo scope.
         

--- a/.github/workflows/CI_win.yml
+++ b/.github/workflows/CI_win.yml
@@ -32,8 +32,10 @@ jobs:
 
     steps:
       - name: Debug Ref Info
+        env:
+          REF: ${{ inputs.REF_TO_CHECKOUT }}
         run: |
-          echo "Checking out ref: ${{ inputs.REF_TO_CHECKOUT }}"
+          echo "Checking out ref: $REF"
 
       - name: Set Default Branch
         run: |

--- a/.github/workflows/CI_win.yml
+++ b/.github/workflows/CI_win.yml
@@ -42,7 +42,7 @@ jobs:
           fi
 
           echo "Checking out ref: $REF_TO_CHECKOUT"
-          echo "$REF_TO_CHECKOUT=$REF_TO_CHECKOUT" >> $GITHUB_OUTPUT
+          echo "REF_TO_CHECKOUT=$REF_TO_CHECKOUT" >> $GITHUB_OUTPUT
 
       - name: Set Default Branch
         run: |

--- a/.github/workflows/CI_win.yml
+++ b/.github/workflows/CI_win.yml
@@ -2,6 +2,12 @@ name: Makefile CI
 
 on:
   workflow_call:
+    inputs:
+      REF_TO_CHECKOUT:
+        description: "The git ref to checkout."
+        required: false
+        default: "refs/heads/main"
+        type: string
     secrets:
       CHECKOUT_SHARED:
         required: true
@@ -25,6 +31,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Debug Ref Info
+        run: |
+          echo "Checking out ref: ${{ inputs.REF_TO_CHECKOUT }}"
+
       - name: Set Default Branch
         run: |
           git config --global init.defaultBranch main
@@ -32,10 +42,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ inputs.REF_TO_CHECKOUT }}
           submodules: recursive
           token: ${{ secrets.CHECKOUT_SHARED }} # Token with full repo scope.
+          # TODO: Remove fetch-depth.
           fetch-depth: 0
         
       - name: Setup Conda

--- a/.github/workflows/CI_win.yml
+++ b/.github/workflows/CI_win.yml
@@ -45,8 +45,6 @@ jobs:
           ref: ${{ inputs.REF_TO_CHECKOUT }}
           submodules: recursive
           token: ${{ secrets.CHECKOUT_SHARED }} # Token with full repo scope.
-          # TODO: Remove fetch-depth.
-          fetch-depth: 0
         
       - name: Setup Conda
         uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/CI_win.yml
+++ b/.github/workflows/CI_win.yml
@@ -31,11 +31,18 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Debug Ref Info
+      - name: Validate and set REF_TO_CHECKOUT
+        id: validate-ref
         env:
-          REF: ${{ inputs.REF_TO_CHECKOUT }}
+          REF_TO_CHECKOUT: ${{ inputs.REF_TO_CHECKOUT }}
         run: |
-          echo "Checking out ref: $REF"
+          if [[ ! "$REF_TO_CHECKOUT" =~ ^refs/(heads|pull|tags)/[A-Za-z0-9._/-]+$ ]]; then
+            echo "Invalid ref: $REF_TO_CHECKOUT"
+            exit 1
+          fi
+
+          echo "Checking out ref: $REF_TO_CHECKOUT"
+          echo "$REF_TO_CHECKOUT=$REF_TO_CHECKOUT" >> $GITHUB_OUTPUT
 
       - name: Set Default Branch
         run: |
@@ -44,7 +51,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.REF_TO_CHECKOUT }}
+          ref: ${{ steps.validate-ref.outputs.REF_TO_CHECKOUT }}
           submodules: recursive
           token: ${{ secrets.CHECKOUT_SHARED }} # Token with full repo scope.
         

--- a/.github/workflows/block_outside_PRs.yml
+++ b/.github/workflows/block_outside_PRs.yml
@@ -37,7 +37,7 @@ jobs:
             echo "No organization specified. Skipping PR closure check."
             echo "ALLOWED_ORG=" >> $GITHUB_OUTPUT
           else
-            echo "Using allowed organization: $AllOWED_ORG"
+            echo "Using allowed organization: $ALLOWED_ORG"
             echo "ALLOWED_ORG=$ALLOWED_ORG" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/block_outside_PRs.yml
+++ b/.github/workflows/block_outside_PRs.yml
@@ -21,7 +21,41 @@ defaults:
     shell: bash -el {0}
 
 jobs:
+  validate-inputs:
+    runs-on: ubuntu-latest
+    outputs:
+      ALLOWED_ORG: ${{ steps.validate-org.outputs.ALLOWED_ORG }}
+      ALLOWED_USERS: ${{ steps.validate-users.outputs.ALLOWED_USERS }}
+
+    steps:
+      - name: Validate and set ALLOWED_ORG
+        id: validate-org
+        env:
+          ALLOWED_ORG: ${{ inputs.ALLOWED_ORG }}
+        run: |
+          if [[ -z "$ALLOWED_ORG" ]]; then
+            echo "No organization specified. Skipping PR closure check."
+            echo "ALLOWED_ORG=" >> $GITHUB_OUTPUT
+          else
+            echo "Using allowed organization: $AllOWED_ORG"
+            echo "ALLOWED_ORG=$ALLOWED_ORG" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Validate and set ALLOWED_USERS
+        id: validate-users
+        env:
+          ALLOWED_USERS: ${{ inputs.ALLOWED_USERS }}
+        run: |
+          if [[ -z "$ALLOWED_USERS" ]]; then
+            echo "No specific users allowed. All users will be checked against the organization."
+            echo "ALLOWED_USERS=" >> $GITHUB_OUTPUT
+          else
+            echo "Using allowed users: $ALLOWED_USERS"
+            echo "ALLOWED_USERS=$ALLOWED_USERS" >> $GITHUB_OUTPUT
+          fi
+
   close-external-prs:
+    needs: validate-inputs
     runs-on: ubuntu-latest
     outputs:
       should_close: ${{ steps.check-permission.outputs.should_close }}
@@ -35,10 +69,10 @@ jobs:
           echo "should_close=$should_close" >> $GITHUB_OUTPUT
 
           prAuthor=$(jq -r '.pull_request.user.login' < "$GITHUB_EVENT_PATH")
-          allowedOrg=${{ inputs.ALLOWED_ORG }}
+          allowedOrg=${{ needs.validate-inputs.outputs.ALLOWED_ORG }}
           prNumber=$(jq -r '.pull_request.number' < "$GITHUB_EVENT_PATH")
 
-          IFS=',' read -ra ALLOWED_USERS <<< "${{ inputs.ALLOWED_USERS }}"
+          IFS=',' read -ra ALLOWED_USERS <<< "${{ needs.validate-inputs.outputs.ALLOWED_USERS }}"
           for user in "${ALLOWED_USERS[@]}"; do
             if [[ "$prAuthor" == "$user" ]]; then
               echo "User $prAuthor is explicitly allowed. PR remains open."
@@ -71,10 +105,10 @@ jobs:
           echo "should_close=$should_close" >> $GITHUB_OUTPUT
 
   close-pr:
-    needs: close-external-prs
+    needs: [close-external-prs, validate-inputs]
     if: needs.close-external-prs.outputs.should_close == 'true'
     uses: crickets-and-comb/shared/.github/workflows/close_pr.yml@main
     with:
       PR_NUMBER: ${{ github.event.pull_request.number }}
       PR_AUTHOR: ${{ github.actor }}
-      REASON: "Only members of ${{ inputs.ALLOWED_ORG }} or explicitly allowed users can open pull requests. Please file an issue for discussion if needed."
+      REASON: "Only members of ${{ needs.validate-inputs.outputs.ALLOWED_ORG }} or explicitly allowed users can open pull requests. Please file an issue for discussion if needed."

--- a/.github/workflows/block_workflow_mods.yml
+++ b/.github/workflows/block_workflow_mods.yml
@@ -9,7 +9,27 @@ on:
         required: false
 
 jobs:
+  validate-inputs:
+    runs-on: ubuntu-latest
+    outputs:
+      ALLOWED_USERS: ${{ steps.validate-users.outputs.ALLOWED_USERS }}
+
+    steps:
+      - name: Validate and set ALLOWED_USERS
+        id: validate-users
+        env:
+          ALLOWED_USERS: ${{ inputs.ALLOWED_USERS }}
+        run: |
+          if [[ -z "$ALLOWED_USERS" ]]; then
+            echo "No specific users allowed. All users will be checked against the organization."
+            echo "ALLOWED_USERS=" >> $GITHUB_OUTPUT
+          else
+            echo "Using allowed users: $ALLOWED_USERS"
+            echo "ALLOWED_USERS=$ALLOWED_USERS" >> $GITHUB_OUTPUT
+          fi  
+
   block:
+    needs: validate-inputs
     runs-on: ubuntu-latest
     outputs:
       should_close: ${{ steps.check-user.outputs.should_close }}
@@ -17,7 +37,7 @@ jobs:
       - name: Check if GITHUB_ACTOR is allowed
         id: check-user
         run: |
-          ALLOWED_USERS_LIST="${{ inputs.ALLOWED_USERS }}"
+          ALLOWED_USERS_LIST="${{ needs.validate-inputs.outputs.ALLOWED_USERS }}"
           IFS=',' read -ra ALLOWED_USERS <<< "$ALLOWED_USERS_LIST"
 
           echo "should_close=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -97,7 +97,7 @@ jobs:
             exit 1
           fi
           echo "Checking out ref: $REF_TO_CHECKOUT"
-          echo "$REF_TO_CHECKOUT=$REF_TO_CHECKOUT" >> $GITHUB_OUTPUT
+          echo "REF_TO_CHECKOUT=$REF_TO_CHECKOUT" >> $GITHUB_OUTPUT
 
   build-dist:
     needs: validate-inputs

--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -15,6 +15,11 @@ on:
         description: 'Name of the dist artifact to upload. Acts like a key.'
         type: string
         required: true
+      REF_TO_CHECKOUT:
+        description: "The git ref to checkout."
+        required: false
+        default: "refs/heads/main"
+        type: string
       UPLOAD_DIST:
         description: 'If passed `true`, upload dist artifact. Allows a test build locally without uploading.'
         type: boolean
@@ -36,6 +41,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Debug Ref Info
+        run: |
+          echo "Checking out ref: ${{ inputs.REF_TO_CHECKOUT }}"
+
       - name: Set Default Branch
         run: |
           git config --global init.defaultBranch main
@@ -43,8 +52,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ inputs.REF_TO_CHECKOUT }}
           submodules: recursive
           token: ${{ secrets.CHECKOUT_SHARED }}
 

--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -36,11 +36,57 @@ env:
   CONDA_VERSION: latest
 
 jobs:
-  build-dist:
-    name: Build Dist
+  validate-inputs:
+    name: Validate Inputs
     runs-on: ubuntu-latest
+    outputs:
+      DIST_DIR: ${{ steps.validate-dist-dir.outputs.DIST_DIR }}
+      PYTHON_BUILD_VERSION: ${{ steps.validate-python-version.outputs.PYTHON_BUILD_VERSION }}
+      PYTHON_PACKAGE_DIST_NAME: ${{ steps.validate-package-name.outputs.PYTHON_PACKAGE_DIST_NAME }}
+      REF_TO_CHECKOUT: ${{ steps.validate-ref.outputs.REF_TO_CHECKOUT }}
 
     steps:
+      - name: Validate and set DIST_DIR
+        id: validate-dist-dir
+        env:
+          DIST_DIR: ${{ inputs.DIST_DIR }}
+        run: |
+          if [[ -z "$DIST_DIR" ]]; then
+            echo "DIST_DIR is required."
+            exit 1
+          fi
+
+          echo "Using DIST_DIR: $DIST_DIR"
+          echo "DIST_DIR=$DIST_DIR" >> $GITHUB_OUTPUT
+
+      - name: Validate and set PYTHON_BUILD_VERSION
+        id: validate-python-version
+        env:
+          PYTHON_BUILD_VERSION: ${{ inputs.PYTHON_BUILD_VERSION }}
+        run: |
+          if [[ -z "$PYTHON_BUILD_VERSION" ]]; then
+            echo "PYTHON_BUILD_VERSION is required."
+            exit 1
+          fi
+          if [[ ! "$PYTHON_BUILD_VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid PYTHON_BUILD_VERSION: $PYTHON_BUILD_VERSION"
+            exit 1
+          fi
+          echo "Using PYTHON_BUILD_VERSION: $PYTHON_BUILD_VERSION"
+          echo "PYTHON_BUILD_VERSION=$PYTHON_BUILD_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Validate and set PYTHON_PACKAGE_DIST_NAME
+        id: validate-package-name
+        env:
+          PYTHON_PACKAGE_DIST_NAME: ${{ inputs.PYTHON_PACKAGE_DIST_NAME }}
+        run: |
+          if [[ -z "$PYTHON_PACKAGE_DIST_NAME" ]]; then
+            echo "PYTHON_PACKAGE_DIST_NAME is required."
+            exit 1
+          fi
+          echo "Using PYTHON_PACKAGE_DIST_NAME: $PYTHON_PACKAGE_DIST_NAME"
+          echo "PYTHON_PACKAGE_DIST_NAME=$PYTHON_PACKAGE_DIST_NAME" >> $GITHUB_OUTPUT
+
       - name: Validate and set REF_TO_CHECKOUT
         id: validate-ref
         env:
@@ -50,10 +96,15 @@ jobs:
             echo "Invalid ref: $REF_TO_CHECKOUT"
             exit 1
           fi
-
           echo "Checking out ref: $REF_TO_CHECKOUT"
           echo "$REF_TO_CHECKOUT=$REF_TO_CHECKOUT" >> $GITHUB_OUTPUT
 
+  build-dist:
+    needs: validate-inputs
+    name: Build Dist
+    runs-on: ubuntu-latest
+
+    steps:
       - name: Set Default Branch
         run: |
           git config --global init.defaultBranch main
@@ -61,7 +112,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ steps.validate-ref.outputs.REF_TO_CHECKOUT }}
+          ref: ${{ needs.validate-inputs.outputs.REF_TO_CHECKOUT }}
           submodules: recursive
           token: ${{ secrets.CHECKOUT_SHARED }}
 
@@ -70,24 +121,24 @@ jobs:
         with:
           auto-activate-base: false
           miniconda-version: ${{ env.CONDA_VERSION }}
-          python-version: ${{ inputs.PYTHON_BUILD_VERSION}}
+          python-version: ${{ needs.validate-inputs.outputs.PYTHON_BUILD_VERSION }}
 
       - name: Build Environment.
         run: |
-          CONDA_ENV_NAME=build_dist_py${{ inputs.PYTHON_BUILD_VERSION}}
+          CONDA_ENV_NAME=build_dist_py${{ needs.validate-inputs.outputs.PYTHON_BUILD_VERSION }}
           echo "CONDA_ENV_NAME=${CONDA_ENV_NAME}" >> $GITHUB_ENV
 
-          make build-env CONDA_ENV_NAME=${CONDA_ENV_NAME} PYTHON_VERSION=${{ inputs.PYTHON_BUILD_VERSION}}
+          make build-env CONDA_ENV_NAME=${CONDA_ENV_NAME} PYTHON_VERSION=${{ needs.validate-inputs.outputs.PYTHON_BUILD_VERSION }}
           conda run -n ${CONDA_ENV_NAME} make install INSTALL_EXTRAS=[build]
 
       - name: Build Package
         run: |
-          conda run -n ${{ env.CONDA_ENV_NAME }} make build-package DIST_DIR=${{ inputs.DIST_DIR }}
+          conda run -n ${{ env.CONDA_ENV_NAME }} make build-package DIST_DIR=${{ needs.validate-inputs.outputs.DIST_DIR }} PYTHON_PACKAGE_DIST_NAME=${{ needs.validate-inputs.outputs.PYTHON_PACKAGE_DIST_NAME }}
 
       - name: Upload Package
         if: ${{ inputs.UPLOAD_DIST }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.PYTHON_PACKAGE_DIST_NAME }}
-          path: ${{ inputs.DIST_DIR }}
+          name: ${{ needs.validate-inputs.outputs.PYTHON_PACKAGE_DIST_NAME }}
+          path: ${{ needs.validate-inputs.outputs.DIST_DIR }}
           overwrite: true

--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -41,11 +41,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Debug Ref Info
+      - name: Validate and set REF_TO_CHECKOUT
+        id: validate-ref
         env:
-          REF: ${{ inputs.REF_TO_CHECKOUT }}
+          REF_TO_CHECKOUT: ${{ inputs.REF_TO_CHECKOUT }}
         run: |
-          echo "Checking out ref: $REF"
+          if [[ ! "$REF_TO_CHECKOUT" =~ ^refs/(heads|pull|tags)/[A-Za-z0-9._/-]+$ ]]; then
+            echo "Invalid ref: $REF_TO_CHECKOUT"
+            exit 1
+          fi
+
+          echo "Checking out ref: $REF_TO_CHECKOUT"
+          echo "$REF_TO_CHECKOUT=$REF_TO_CHECKOUT" >> $GITHUB_OUTPUT
 
       - name: Set Default Branch
         run: |
@@ -54,7 +61,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.REF_TO_CHECKOUT }}
+          ref: ${{ steps.validate-ref.outputs.REF_TO_CHECKOUT }}
           submodules: recursive
           token: ${{ secrets.CHECKOUT_SHARED }}
 

--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Build Package
         run: |
-          conda run -n ${{ env.CONDA_ENV_NAME }} make build-package DIST_DIR=${{ needs.validate-inputs.outputs.DIST_DIR }} PYTHON_PACKAGE_DIST_NAME=${{ needs.validate-inputs.outputs.PYTHON_PACKAGE_DIST_NAME }}
+          conda run -n ${{ env.CONDA_ENV_NAME }} make build-package DIST_DIR=${{ needs.validate-inputs.outputs.DIST_DIR }}
 
       - name: Upload Package
         if: ${{ inputs.UPLOAD_DIST }}

--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -42,8 +42,10 @@ jobs:
 
     steps:
       - name: Debug Ref Info
+        env:
+          REF: ${{ inputs.REF_TO_CHECKOUT }}
         run: |
-          echo "Checking out ref: ${{ inputs.REF_TO_CHECKOUT }}"
+          echo "Checking out ref: $REF"
 
       - name: Set Default Branch
         run: |

--- a/.github/workflows/close_pr.yml
+++ b/.github/workflows/close_pr.yml
@@ -17,19 +17,76 @@ on:
         required: true
 
 jobs:
+  validate-inputs:
+    runs-on: ubuntu-latest
+    outputs:
+      PR_NUMBER: ${{ steps.validate-pr.outputs.PR_NUMBER }}
+      PR_AUTHOR: ${{ steps.validate-author.outputs.PR_AUTHOR }}
+      REASON: ${{ steps.validate-reason.outputs.REASON }}
+
+    steps:
+      - name: Validate PR Number
+        id: validate-pr
+        env:
+          PR_NUMBER: ${{ inputs.PR_NUMBER }}
+        run: |
+          if [[ -z "$PR_NUMBER" ]]; then
+            echo "PR_NUMBER is required."
+            exit 1
+          fi
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "Invalid PR_NUMBER: $PR_NUMBER"
+            exit 1
+          fi
+          echo "Using PR_NUMBER: $PR_NUMBER"
+          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_OUTPUT
+
+      - name: Validate PR Author
+        id: validate-author
+        env:
+          PR_AUTHOR: ${{ inputs.PR_AUTHOR }}
+        run: |
+          if [[ -z "$PR_AUTHOR" ]]; then
+            echo "PR_AUTHOR is required."
+            exit 1
+          fi
+          if ! [[ "$PR_AUTHOR" =~ ^[A-Za-z0-9_-]+$ ]]; then
+            echo "Invalid PR_AUTHOR: $PR_AUTHOR"
+            exit 1
+          fi
+          echo "Using PR_AUTHOR: $PR_AUTHOR"
+          echo "PR_AUTHOR=$PR_AUTHOR" >> $GITHUB_OUTPUT
+
+      - name: Validate Reason
+        id: validate-reason
+        env:
+          REASON: ${{ inputs.REASON }}
+        run: |
+          if [[ -z "$REASON" ]]; then
+            echo "REASON is required."
+            exit 1
+          fi
+          if ! [[ "$REASON" =~ ^[A-Za-z0-9_ -]+$ ]]; then
+            echo "Invalid REASON: $REASON"
+            exit 1
+          fi
+          echo "Using REASON: $REASON"
+          echo "REASON=$REASON" >> $GITHUB_OUTPUT
+
   close-pr:
+    needs: validate-inputs
     runs-on: ubuntu-latest
     steps:
       - name: Close Pull Request
         run: |
-          echo "Closing PR #${{ inputs.PR_NUMBER }}: ${{ inputs.REASON }}"
+          echo "Closing PR #${{ needs.validate-inputs.outputs.PR_NUMBER }}: ${{ needs.validate-inputs.outputs.REASON }}"
 
           curl -s -S -X PATCH -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
                -H "Accept: application/vnd.github.v3+json" \
                -d '{"state": "closed"}' \
-               https://api.github.com/repos/$GITHUB_REPOSITORY/pulls/${{ inputs.PR_NUMBER }} || true
+               https://api.github.com/repos/$GITHUB_REPOSITORY/pulls/${{ needs.validate-inputs.outputs.PR_NUMBER }} || true
 
           curl -s -S -X POST -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
                -H "Accept: application/vnd.github.v3+json" \
-               -d "{\"body\": \"**Pull request closed**\n\nHi @${{ inputs.PR_AUTHOR }}, this PR was closed automatically. Reason: ${{ inputs.REASON }}\"}" \
-               https://api.github.com/repos/$GITHUB_REPOSITORY/issues/${{ inputs.PR_NUMBER }}/comments || true
+               -d "{\"body\": \"**Pull request closed**\n\nHi @${{ needs.validate-inputs.outputs.PR_AUTHOR }}, this PR was closed automatically. Reason: ${{ steps.validate-reason.outputs.REASON }}\"}" \
+               https://api.github.com/repos/$GITHUB_REPOSITORY/issues/${{ needs.validate-inputs.outputs.PR_NUMBER }}/comments || true

--- a/.github/workflows/close_pr.yml
+++ b/.github/workflows/close_pr.yml
@@ -88,5 +88,5 @@ jobs:
 
           curl -s -S -X POST -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
                -H "Accept: application/vnd.github.v3+json" \
-               -d "{\"body\": \"**Pull request closed**\n\nHi @${{ needs.validate-inputs.outputs.PR_AUTHOR }}, this PR was closed automatically. Reason: ${{ steps.validate-reason.outputs.REASON }}\"}" \
+               -d "{\"body\": \"**Pull request closed**\n\nHi @${{ needs.validate-inputs.outputs.PR_AUTHOR }}, this PR was closed automatically. Reason: ${{ needs.validate-inputs.outputs.REASON }}\"}" \
                https://api.github.com/repos/$GITHUB_REPOSITORY/issues/${{ needs.validate-inputs.outputs.PR_NUMBER }}/comments || true

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -22,7 +22,31 @@ env:
   DOC_BUILD_DIR: docs/_build/
 
 jobs:
+  validate-inputs:
+    name: Validate Inputs
+    runs-on: ubuntu-latest
+    outputs:
+      PYTHON_BUILD_VERSION: ${{ steps.validate-python-version.outputs.PYTHON_BUILD_VERSION }}
+
+    steps:
+      - name: Validate and set PYTHON_BUILD_VERSION
+        id: validate-python-version
+        env:
+          PYTHON_BUILD_VERSION: ${{ inputs.PYTHON_BUILD_VERSION }}
+        run: |
+          if [[ -z "$PYTHON_BUILD_VERSION" ]]; then
+            echo "PYTHON_BUILD_VERSION is required."
+            exit 1
+          fi
+          if [[ ! "$PYTHON_BUILD_VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid PYTHON_BUILD_VERSION: $PYTHON_BUILD_VERSION"
+            exit 1
+          fi
+          echo "Using PYTHON_BUILD_VERSION: $PYTHON_BUILD_VERSION"
+          echo "PYTHON_BUILD_VERSION=$PYTHON_BUILD_VERSION" >> $GITHUB_OUTPUT
+
   deploy-doc:
+    needs: validate-inputs
     name: Build and Deploy Documentation
     runs-on: ubuntu-latest
     permissions:
@@ -45,14 +69,14 @@ jobs:
         with:
           auto-activate-base: false
           miniconda-version: ${{ env.CONDA_VERSION }}
-          python-version: ${{ inputs.PYTHON_BUILD_VERSION}}
+          python-version: ${{ needs.validate-inputs.outputs.PYTHON_BUILD_VERSION}}
 
       - name: Build Environment
         run: |
-          CONDA_ENV_NAME=build_doc_py${{ inputs.PYTHON_BUILD_VERSION}}
+          CONDA_ENV_NAME=build_doc_py${{ needs.validate-inputs.outputs.PYTHON_BUILD_VERSION }}
           echo "CONDA_ENV_NAME=${CONDA_ENV_NAME}" >> $GITHUB_ENV
 
-          make build-env CONDA_ENV_NAME=${CONDA_ENV_NAME} PYTHON_VERSION=${{ inputs.PYTHON_BUILD_VERSION}}
+          make build-env CONDA_ENV_NAME=${CONDA_ENV_NAME} PYTHON_VERSION=${{ needs.validate-inputs.outputs.PYTHON_BUILD_VERSION }}
           conda run -n ${CONDA_ENV_NAME} make install INSTALL_EXTRAS=[doc]
 
       - name: Build Documentation

--- a/.github/workflows/release_to_github.yml
+++ b/.github/workflows/release_to_github.yml
@@ -24,7 +24,56 @@ defaults:
     shell: bash -el {0}
 
 jobs:
+  validate-inputs:
+    name: Validate Inputs
+    runs-on: ubuntu-latest
+    outputs:
+      DIST_DIR: ${{ steps.validate-dist-dir.outputs.DIST_DIR }}
+      PYTHON_BUILD_VERSION: ${{ steps.validate-python-version.outputs.PYTHON_BUILD_VERSION }}
+      PYTHON_PACKAGE_DIST_NAME: ${{ steps.validate-package-name.outputs.PYTHON_PACKAGE_DIST_NAME }}
+
+    steps:
+      - name: Validate and set DIST_DIR
+        id: validate-dist-dir
+        env:
+          DIST_DIR: ${{ inputs.DIST_DIR }}
+        run: |
+          if [[ -z "$DIST_DIR" ]]; then
+            echo "DIST_DIR is required."
+            exit 1
+          fi
+
+          echo "Using DIST_DIR: $DIST_DIR"
+          echo "DIST_DIR=$DIST_DIR" >> $GITHUB_OUTPUT
+
+      - name: Validate and set PYTHON_BUILD_VERSION
+        id: validate-python-version
+        env:
+          PYTHON_BUILD_VERSION: ${{ inputs.PYTHON_BUILD_VERSION }}
+        run: |
+          if [[ -z "$PYTHON_BUILD_VERSION" ]]; then
+            echo "PYTHON_BUILD_VERSION is required."
+            exit 1
+          fi
+
+          echo "Using PYTHON_BUILD_VERSION: $PYTHON_BUILD_VERSION"
+          echo "PYTHON_BUILD_VERSION=$PYTHON_BUILD_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Validate and set PYTHON_PACKAGE_DIST_NAME
+        id: validate-package-name
+        env:
+          PYTHON_PACKAGE_DIST_NAME: ${{ inputs.PYTHON_PACKAGE_DIST_NAME }}
+        run: |
+          if [[ -z "$PYTHON_PACKAGE_DIST_NAME" ]]; then
+            echo "PYTHON_PACKAGE_DIST_NAME is required."
+            exit 1
+          fi
+
+          echo "Using PYTHON_PACKAGE_DIST_NAME: $PYTHON_PACKAGE_DIST_NAME"
+          echo "PYTHON_PACKAGE_DIST_NAME=$PYTHON_PACKAGE_DIST_NAME" >> $GITHUB_OUTPUT
+          
   github-release:
+    needs: validate-inputs
     name: Sign distribution with Sigstore and Upload to GitHub Release
     runs-on: ubuntu-latest
     permissions:
@@ -41,28 +90,28 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ inputs.PYTHON_BUILD_VERSION }}
+          python-version: ${{ needs.validate-inputs.outputs.PYTHON_BUILD_VERSION }}
 
       - name: Download Dist
         uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.PYTHON_PACKAGE_DIST_NAME }}
-          path: ${{ inputs.DIST_DIR }}
+          name: ${{ needs.validate-inputs.outputs.PYTHON_PACKAGE_DIST_NAME }}
+          path: ${{ needs.validate-inputs.outputs.DIST_DIR }}
 
       - name: Sign Dist with Sigstore
         uses: sigstore/gh-action-sigstore-python@v3.0.0
         with:
           inputs: >-
-            ./${{ inputs.DIST_DIR }}/*.tar.gz
-            ./${{ inputs.DIST_DIR }}/*.whl
+            ./${{ needs.validate-inputs.outputs.DIST_DIR }}/*.tar.gz
+            ./${{ needs.validate-inputs.outputs.DIST_DIR }}/*.whl
 
       - name: Get Version from Dist
         id: extract_version
         run: |
           pip install pkginfo -c shared/constraints.txt
           
-          tarball=$(ls ${{ inputs.DIST_DIR }}/*.tar.gz | head -n 1)
-          wheel=$(ls ${{ inputs.DIST_DIR }}/*.whl | head -n 1)
+          tarball=$(ls ${{ needs.validate-inputs.outputs.DIST_DIR }}/*.tar.gz | head -n 1)
+          wheel=$(ls ${{ needs.validate-inputs.outputs.DIST_DIR }}/*.whl | head -n 1)
 
           if [ -f "$tarball" ]; then
             version=$(python -c "import pkginfo; info = pkginfo.get_metadata('$tarball'); print(info.version)")
@@ -89,5 +138,5 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: >-
           gh release upload
-          '${{ env.VERSION_TAG }}' ${{ inputs.DIST_DIR }}/**
+          '${{ env.VERSION_TAG }}' ${{ needs.validate-inputs.outputs.DIST_DIR }}/**
           --repo '${{ github.repository }}'

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           if [[ -z "$RELEASE_VERSION" ]]; then
             echo "RELEASE_VERSION is not set, using version from setup.cfg."
-            echo "RELEASE_VERSION=$(python -c 'import configparser; cfg = configparser.ConfigParser(); cfg.read("setup.cfg"); print(cfg["metadata"]["version"])')" >> $GITHUB_OUTPUT
+            echo "RELEASE_VERSION=$(python -c 'import configparser; cfg = configparser.ConfigParser(); cfg.read(\"setup.cfg\"); print(cfg[\"metadata\"][\"version\"])')" >> $GITHUB_OUTPUT
           else
             echo "Using RELEASE_VERSION: $RELEASE_VERSION"
             echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -23,7 +23,41 @@ env:
   CONDA_VERSION: latest
 
 jobs:
+  validate-and-set-inputs:
+    name: Validate and Set Inputs
+    runs-on: ubuntu-latest
+    outputs:
+      RELEASE_VERSION: ${{ steps.validate-release-version.outputs.RELEASE_VERSION }}
+      TEST_OR_PROD: ${{ steps.validate-test.outputs.TEST_OR_PROD }}
+
+    steps:
+      - name: Validate and set RELEASE_VERSION
+        id: validate-release-version
+        env:
+          RELEASE_VERSION: ${{ inputs.RELEASE_VERSION }}
+        run: |
+          if [[ -z "$RELEASE_VERSION" ]]; then
+            echo "RELEASE_VERSION is not set, using version from setup.cfg."
+            echo "RELEASE_VERSION=$(python -c 'import configparser; cfg = configparser.ConfigParser(); cfg.read("setup.cfg"); print(cfg["metadata"]["version"])')" >> $GITHUB_OUTPUT
+          else
+            echo "Using RELEASE_VERSION: $RELEASE_VERSION"
+            echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Validate and set TEST_OR_PROD
+        id: validate-test
+        env:
+          TEST_OR_PROD: ${{ inputs.TEST_OR_PROD }}
+        run: |
+          if [[ -z "$TEST_OR_PROD" ]]; then
+            echo "TEST_OR_PROD is required."
+            exit 1
+          fi
+          echo "Using TEST_OR_PROD: $TEST_OR_PROD"
+          echo "TEST_OR_PROD=$TEST_OR_PROD" >> $GITHUB_OUTPUT
+  
   test-published-package:
+    needs: validate-and-set-inputs
     name: Test Published Package on (Test)PyPi
     runs-on: ${{ matrix.os }}
     strategy:
@@ -61,18 +95,13 @@ jobs:
           echo "PACKAGE_NAME=${PACKAGE_NAME}" >> $GITHUB_ENV
           PACKAGE_NAME_HYPHEN=$(echo ${PACKAGE_NAME} | tr '_' '-')
 
-          PACKAGE_VERSION=${{ inputs.RELEASE_VERSION }}
-          if [[ -z "${{ inputs.RELEASE_VERSION }}" ]]; then
-            PACKAGE_VERSION=$(python -c "import configparser; cfg = configparser.ConfigParser(); cfg.read('setup.cfg'); print(cfg['metadata']['version'])")
-          fi
-
           # CVE-2018-20225 ignored here. --extra-index-url usage is secure in this context.
           TEST_PYPI_FLAG=""
-          if [[ "${{ inputs.TEST_OR_PROD }}" == "test" ]]; then
+          if [[ "${{ needs.validate-and-set-inputs.outputs.TEST_OR_PROD }}" == "test" ]]; then
             TEST_PYPI_FLAG="-i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/"
           fi
 
-          conda run -n ${{ env.ENV_NAME }} pip install ${TEST_PYPI_FLAG} ${PACKAGE_NAME_HYPHEN}==${PACKAGE_VERSION}
+          conda run -n ${{ env.ENV_NAME }} pip install ${TEST_PYPI_FLAG} ${PACKAGE_NAME_HYPHEN}==${{ needs.validate-and-set-inputs.outputs.RELEASE_VERSION }}
 
       - name: Run Tests
         run: |

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ SAFETY_API_KEY ?= $(shell grep SAFETY_API_KEY .env | cut -d '=' -f2) # Your safe
 SAFETY_KEY_FLAG = $(if $(SAFETY_API_KEY),--key $(SAFETY_API_KEY),)
 CHECKOUT_SHARED ?= $(shell grep CHECKOUT_SHARED .env | cut -d '=' -f2)
 ORG_READ_TOKEN ?= $(shell grep ORG_READ_TOKEN .env | cut -d '=' -f2)
+REF_TO_CHECKOUT ?= $(shell GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "") && if [[ -z "$GIT_BRANCH" ]]; then exit 1; fi && echo "refs/heads/$GIT_BRANCH")
 
 DOC_BUILD_DIR ?= docs/_build/
 DIST_DIR ?= dist/
@@ -109,4 +110,4 @@ run-act: # Run the CI-CD workflow.
 
 	act ${ACT_RUN_EVENT} -W .github/workflows/CI_CD_act.yml --defaultbranch main ${MATRIX_OS_FLAG} ${MATRIX_PYTHON_VERSION_FLAG} \
 		-s CHECKOUT_SHARED=${CHECKOUT_SHARED} -s ORG_READ_TOKEN=${ORG_READ_TOKEN} -s SAFETY_API_KEY=${SAFETY_API_KEY} \
-		--input TEST_OR_PROD=${TEST_OR_PROD} --input PYTHON_BUILD_VERSION=${PYTHON_BUILD_VERSION}
+		--input TEST_OR_PROD=${TEST_OR_PROD} --input PYTHON_BUILD_VERSION=${PYTHON_BUILD_VERSION} --input REF_TO_CHECKOUT=${REF_TO_CHECKOUT}

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ SAFETY_KEY_FLAG = $(if $(SAFETY_API_KEY),--key $(SAFETY_API_KEY),)
 CHECKOUT_SHARED ?= $(shell grep CHECKOUT_SHARED .env | cut -d '=' -f2)
 ORG_READ_TOKEN ?= $(shell grep ORG_READ_TOKEN .env | cut -d '=' -f2)
 _GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
-REF_TO_CHECKOUT ?= "refs/heads/$(_GIT_BRANCH)"
+REF_TO_CHECKOUT ?= refs/heads/$(_GIT_BRANCH)
 
 DOC_BUILD_DIR ?= docs/_build/
 DIST_DIR ?= dist/

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ SAFETY_API_KEY ?= $(shell grep SAFETY_API_KEY .env | cut -d '=' -f2) # Your safe
 SAFETY_KEY_FLAG = $(if $(SAFETY_API_KEY),--key $(SAFETY_API_KEY),)
 CHECKOUT_SHARED ?= $(shell grep CHECKOUT_SHARED .env | cut -d '=' -f2)
 ORG_READ_TOKEN ?= $(shell grep ORG_READ_TOKEN .env | cut -d '=' -f2)
-REF_TO_CHECKOUT ?= $(shell GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "") && if [[ -z "$GIT_BRANCH" ]]; then exit 1; fi && echo "refs/heads/$GIT_BRANCH")
+_GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+REF_TO_CHECKOUT ?= "refs/heads/$(_GIT_BRANCH)"
 
 DOC_BUILD_DIR ?= docs/_build/
 DIST_DIR ?= dist/

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Some shared reusable workflows are meant to be called from workflows triggered b
 
 To address this, these reusable workflows (e.g. `.github/workflows/CI.yml`) offer an optional input called `REF_TO_CHECKOUT`. You can set this input to be the PR merge ref so it runs within the base repo instead of the forked repo. See the `reference_package` `.github/workflows/PR_CI_CD.yml` for an example of how to do this.
 
-`REF_TO_CHECKOUT` is option in case you want to run the workflow on a trigger that does not use inputs, like the `schedule` trigger.
+`REF_TO_CHECKOUT` is optional in case you want to run the workflow on a trigger that does not use inputs, like the `schedule` trigger.
 
 #### Publishing to PyPi
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,14 @@ See also the `reference_package` `.github/workflows/test_install_dispatch.yml` w
 
 While wrapping a single workflow for manual dispatch can be handy, you'll also want to wrap these shared workflows into a single workflow calling them in the desired order (QC/test, build, publish, test installation, deploy docs). See the `reference_package` `.github/workflows/CI_CD.yml` workflow for an example: https://github.com/crickets-and-comb/reference_package
 
+#### ATTENTION: setting `REF_TO_CHECKOUT`
+
+Some shared reusable workflows are meant to be called from workflows triggered by pull requests. A pull request from a forked repo then poses a security risk because it will run the head of the forked repo branch, which can trigger malicious actions.
+
+To address this, these reusable workflows (e.g. `.github/workflows/CI.yml`) offer an optional input called `REF_TO_CHECKOUT`. You can set this input to be the PR merge ref so it runs within the base repo instead of the forked repo. See the `reference_package` `.github/workflows/PR_CI_CD.yml` for an example of how to do this.
+
+`REF_TO_CHECKOUT` is option in case you want to run the workflow on a trigger that does not use inputs, like the `schedule` trigger.
+
 #### Publishing to PyPi
 
 Shared workflows are split into different aspects of CI/CD, but they don't cover all of them. Specifically, they don't cover publishing packages to PyPi. This is because PyPi doesn't allow trusted publishing from reusable workflows. See the `reference_package` `.github/workflows/CI_CD.yml` workflow for an example: https://github.com/crickets-and-comb/reference_package. Here we've defined publishing jobs within the same workflow that calls shared workflows to create a full CI/CD pipeline.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 # TODO: Drop CVE-2024-34997 from jake_whitelist when dropping Python 3.12 support. https://github.com/crickets-and-comb/shared/issues/34
 [metadata]
 name = shared
-version = 0.15.3
+version = 0.16.0
 description = Shared resources for Crickets and Comb projects.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 # TODO: Drop CVE-2024-34997 from jake_whitelist when dropping Python 3.12 support. https://github.com/crickets-and-comb/shared/issues/34
 [metadata]
 name = shared
-version = 0.15.2
+version = 0.15.3
 description = Shared resources for Crickets and Comb projects.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Allows calling workflows to pass ref to workflows intended to run on PR trigger (`CI.yml`/`CI_win.yml` and `build_dist.yml`), using the `REF_TO_CHECKOUT` input.

Avoids code injection by wrapping inputs in env var.

Also removes unnecessary fetch depth from `CI_win.yml` checkout.