### PR TITLE
Feature/kaleb coberly/try getting pr ref from within shared

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,12 +2,6 @@ name: Makefile CI
 
 on:
   workflow_call:
-    inputs:
-      REF_TO_CHECKOUT:
-        description: "The git ref to checkout."
-        required: false
-        default: "refs/heads/main"
-        type: string
     secrets:
       CHECKOUT_SHARED:
         required: true
@@ -31,18 +25,19 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Validate and set REF_TO_CHECKOUT
-        id: validate-ref
-        env:
-          REF_TO_CHECKOUT: ${{ inputs.REF_TO_CHECKOUT }}
+      - name: Set ref
+        id: set-ref
         run: |
-          if [[ ! "$REF_TO_CHECKOUT" =~ ^refs/(heads|pull|tags)/[A-Za-z0-9._/-]+$ ]]; then
-            echo "Invalid ref: $REF_TO_CHECKOUT"
-            exit 1
+          if [[ "${{ github.event_name }}" == "pull_request_target" && -n "${{ github.event.pull_request.number || '' }}" ]]; then
+            echo "Using PR merge ref to avoid running workflows on forked repo."
+            echo "ref=refs/pull/${{ github.event.pull_request.number }}/merge" >> $GITHUB_OUTPUT
+          elif [[ -n "${{ github.ref || '' }}" ]]; then
+            echo "Using github.ref"
+            echo "ref=${{ github.ref }}" >> $GITHUB_OUTPUT
+          else
+            echo "Using fallback default ref"
+            echo "ref=refs/heads/main" >> $GITHUB_OUTPUT
           fi
-
-          echo "Checking out ref: $REF_TO_CHECKOUT"
-          echo "REF_TO_CHECKOUT=$REF_TO_CHECKOUT" >> $GITHUB_OUTPUT
 
       - name: Set Default Branch
         run: |
@@ -51,7 +46,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ steps.validate-ref.outputs.REF_TO_CHECKOUT }}
+          ref: ${{ steps.set-ref.outputs.ref }}
           submodules: recursive
           token: ${{ secrets.CHECKOUT_SHARED }} # Token with full repo scope.
         

--- a/.github/workflows/CI_win.yml
+++ b/.github/workflows/CI_win.yml
@@ -2,12 +2,6 @@ name: Makefile CI
 
 on:
   workflow_call:
-    inputs:
-      REF_TO_CHECKOUT:
-        description: "The git ref to checkout."
-        required: false
-        default: "refs/heads/main"
-        type: string
     secrets:
       CHECKOUT_SHARED:
         required: true
@@ -31,18 +25,19 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Validate and set REF_TO_CHECKOUT
-        id: validate-ref
-        env:
-          REF_TO_CHECKOUT: ${{ inputs.REF_TO_CHECKOUT }}
+      - name: Set ref
+        id: set-ref
         run: |
-          if [[ ! "$REF_TO_CHECKOUT" =~ ^refs/(heads|pull|tags)/[A-Za-z0-9._/-]+$ ]]; then
-            echo "Invalid ref: $REF_TO_CHECKOUT"
-            exit 1
+          if [[ "${{ github.event_name }}" == "pull_request_target" && -n "${{ github.event.pull_request.number || '' }}" ]]; then
+            echo "Using PR merge ref to avoid running workflows on forked repo."
+            echo "ref=refs/pull/${{ github.event.pull_request.number }}/merge" >> $GITHUB_OUTPUT
+          elif [[ -n "${{ github.ref || '' }}" ]]; then
+            echo "Using github.ref"
+            echo "ref=${{ github.ref }}" >> $GITHUB_OUTPUT
+          else
+            echo "Using fallback default ref"
+            echo "ref=refs/heads/main" >> $GITHUB_OUTPUT
           fi
-
-          echo "Checking out ref: $REF_TO_CHECKOUT"
-          echo "REF_TO_CHECKOUT=$REF_TO_CHECKOUT" >> $GITHUB_OUTPUT
 
       - name: Set Default Branch
         run: |
@@ -51,7 +46,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ steps.validate-ref.outputs.REF_TO_CHECKOUT }}
+          ref: ${{ steps.set-ref.outputs.ref }}
           submodules: recursive
           token: ${{ secrets.CHECKOUT_SHARED }} # Token with full repo scope.
         

--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -15,11 +15,6 @@ on:
         description: 'Name of the dist artifact to upload. Acts like a key.'
         type: string
         required: true
-      REF_TO_CHECKOUT:
-        description: "The git ref to checkout."
-        required: false
-        default: "refs/heads/main"
-        type: string
       UPLOAD_DIST:
         description: 'If passed `true`, upload dist artifact. Allows a test build locally without uploading.'
         type: boolean
@@ -43,7 +38,6 @@ jobs:
       DIST_DIR: ${{ steps.validate-dist-dir.outputs.DIST_DIR }}
       PYTHON_BUILD_VERSION: ${{ steps.validate-python-version.outputs.PYTHON_BUILD_VERSION }}
       PYTHON_PACKAGE_DIST_NAME: ${{ steps.validate-package-name.outputs.PYTHON_PACKAGE_DIST_NAME }}
-      REF_TO_CHECKOUT: ${{ steps.validate-ref.outputs.REF_TO_CHECKOUT }}
 
     steps:
       - name: Validate and set DIST_DIR
@@ -87,18 +81,6 @@ jobs:
           echo "Using PYTHON_PACKAGE_DIST_NAME: $PYTHON_PACKAGE_DIST_NAME"
           echo "PYTHON_PACKAGE_DIST_NAME=$PYTHON_PACKAGE_DIST_NAME" >> $GITHUB_OUTPUT
 
-      - name: Validate and set REF_TO_CHECKOUT
-        id: validate-ref
-        env:
-          REF_TO_CHECKOUT: ${{ inputs.REF_TO_CHECKOUT }}
-        run: |
-          if [[ ! "$REF_TO_CHECKOUT" =~ ^refs/(heads|pull|tags)/[A-Za-z0-9._/-]+$ ]]; then
-            echo "Invalid ref: $REF_TO_CHECKOUT"
-            exit 1
-          fi
-          echo "Checking out ref: $REF_TO_CHECKOUT"
-          echo "REF_TO_CHECKOUT=$REF_TO_CHECKOUT" >> $GITHUB_OUTPUT
-
   build-dist:
     needs: validate-inputs
     name: Build Dist
@@ -108,11 +90,25 @@ jobs:
       - name: Set Default Branch
         run: |
           git config --global init.defaultBranch main
+      
+      - name: Set ref
+        id: set-ref
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request_target" && -n "${{ github.event.pull_request.number || '' }}" ]]; then
+            echo "Using PR merge ref to avoid running workflows on forked repo."
+            echo "ref=refs/pull/${{ github.event.pull_request.number }}/merge" >> $GITHUB_OUTPUT
+          elif [[ -n "${{ github.ref || '' }}" ]]; then
+            echo "Using github.ref"
+            echo "ref=${{ github.ref }}" >> $GITHUB_OUTPUT
+          else
+            echo "Using fallback default ref"
+            echo "ref=refs/heads/main" >> $GITHUB_OUTPUT
+          fi
 
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.validate-inputs.outputs.REF_TO_CHECKOUT }}
+          ref: ${{ steps.set-ref.outputs.ref }}
           submodules: recursive
           token: ${{ secrets.CHECKOUT_SHARED }}
 

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,6 @@ SAFETY_API_KEY ?= $(shell grep SAFETY_API_KEY .env | cut -d '=' -f2) # Your safe
 SAFETY_KEY_FLAG = $(if $(SAFETY_API_KEY),--key $(SAFETY_API_KEY),)
 CHECKOUT_SHARED ?= $(shell grep CHECKOUT_SHARED .env | cut -d '=' -f2)
 ORG_READ_TOKEN ?= $(shell grep ORG_READ_TOKEN .env | cut -d '=' -f2)
-_GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
-REF_TO_CHECKOUT ?= refs/heads/$(_GIT_BRANCH)
 
 DOC_BUILD_DIR ?= docs/_build/
 DIST_DIR ?= dist/
@@ -111,4 +109,4 @@ run-act: # Run the CI-CD workflow.
 
 	act ${ACT_RUN_EVENT} -W .github/workflows/CI_CD_act.yml --defaultbranch main ${MATRIX_OS_FLAG} ${MATRIX_PYTHON_VERSION_FLAG} \
 		-s CHECKOUT_SHARED=${CHECKOUT_SHARED} -s ORG_READ_TOKEN=${ORG_READ_TOKEN} -s SAFETY_API_KEY=${SAFETY_API_KEY} \
-		--input TEST_OR_PROD=${TEST_OR_PROD} --input PYTHON_BUILD_VERSION=${PYTHON_BUILD_VERSION} --input REF_TO_CHECKOUT=${REF_TO_CHECKOUT}
+		--input TEST_OR_PROD=${TEST_OR_PROD} --input PYTHON_BUILD_VERSION=${PYTHON_BUILD_VERSION}

--- a/README.md
+++ b/README.md
@@ -112,14 +112,6 @@ See also the `reference_package` `.github/workflows/test_install_dispatch.yml` w
 
 While wrapping a single workflow for manual dispatch can be handy, you'll also want to wrap these shared workflows into a single workflow calling them in the desired order (QC/test, build, publish, test installation, deploy docs). See the `reference_package` `.github/workflows/CI_CD.yml` workflow for an example: https://github.com/crickets-and-comb/reference_package
 
-#### ATTENTION: setting `REF_TO_CHECKOUT`
-
-Some shared reusable workflows are meant to be called from workflows triggered by pull requests. A pull request from a forked repo then poses a security risk because it will run the head of the forked repo branch, which can trigger malicious actions.
-
-To address this, these reusable workflows (e.g. `.github/workflows/CI.yml`) offer an optional input called `REF_TO_CHECKOUT`. You can set this input to be the PR merge ref so it runs within the base repo instead of the forked repo. See the `reference_package` `.github/workflows/PR_CI_CD.yml` for an example of how to do this.
-
-`REF_TO_CHECKOUT` is optional in case you want to run the workflow on a trigger that does not use inputs, like the `schedule` trigger.
-
 #### Publishing to PyPi
 
 Shared workflows are split into different aspects of CI/CD, but they don't cover all of them. Specifically, they don't cover publishing packages to PyPi. This is because PyPi doesn't allow trusted publishing from reusable workflows. See the `reference_package` `.github/workflows/CI_CD.yml` workflow for an example: https://github.com/crickets-and-comb/reference_package. Here we've defined publishing jobs within the same workflow that calls shared workflows to create a full CI/CD pipeline.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 # TODO: Drop CVE-2024-34997 from jake_whitelist when dropping Python 3.12 support. https://github.com/crickets-and-comb/shared/issues/34
 [metadata]
 name = shared
-version = 0.16.0
+version = 0.17.0
 description = Shared resources for Crickets and Comb projects.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Set the checkout ref from within the reusable workflows instead of accepting it as input, since reusable workflows inherit GitHub event context.